### PR TITLE
add `LICENSE` file and update header comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+# License for shoalsoft-pants-telemetry-plugin
+
+Copyright (c) 2025 Shoal Software LLC. All rights reserved.
+
+This is commercial software and cannot be used without prior permission.
+
+This software and associated documentation files (the "Software") may only be
+used, if you (and any entity that you represent) have agreed to, and are in compliance
+with, any separate licensing agreement between you and Shoal Software LLC covering
+this software. Otherwise, you may not use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell this Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/python/shoalsoft/pants_mcp_plugin/BUILD
+++ b/src/python/shoalsoft/pants_mcp_plugin/BUILD
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Shoal Software LLC. All rights reserved.
 #
 # This is commercial software and cannot be used without prior permission.
+# See the included LICENSE file for further specific terms and conditions.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/src/python/shoalsoft/pants_mcp_plugin/goals.py
+++ b/src/python/shoalsoft/pants_mcp_plugin/goals.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Shoal Software LLC. All rights reserved.
 #
 # This is commercial software and cannot be used without prior permission.
+# See the included LICENSE file for further specific terms and conditions.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/src/python/shoalsoft/pants_mcp_plugin/mcp_server.py
+++ b/src/python/shoalsoft/pants_mcp_plugin/mcp_server.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Shoal Software LLC. All rights reserved.
 #
 # This is commercial software and cannot be used without prior permission.
+# See the included LICENSE file for further specific terms and conditions.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/src/python/shoalsoft/pants_mcp_plugin/pants_integration_testutil.py
+++ b/src/python/shoalsoft/pants_mcp_plugin/pants_integration_testutil.py
@@ -15,6 +15,8 @@
 # NOTE: Vendored from Pants sources to add `chdir` parameter.
 # Non-upstreamed changes are:
 #   Copyright (C) 2025 Shoal Software LLC. All rights reserved.
+#
+# See the included LICENSE file for further specific terms and conditions.
 
 from __future__ import annotations
 

--- a/src/python/shoalsoft/pants_mcp_plugin/plugin_integration_test.py
+++ b/src/python/shoalsoft/pants_mcp_plugin/plugin_integration_test.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Shoal Software LLC. All rights reserved.
 #
 # This is commercial software and cannot be used without prior permission.
+# See the included LICENSE file for further specific terms and conditions.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/src/python/shoalsoft/pants_mcp_plugin/register.py
+++ b/src/python/shoalsoft/pants_mcp_plugin/register.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Shoal Software LLC. All rights reserved.
 #
 # This is commercial software and cannot be used without prior permission.
+# See the included LICENSE file for further specific terms and conditions.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
Add a `LICENSE` file with the commercial terms and update header comments to refer to it.