### PR TITLE
add GHA release workflow

### DIFF
--- a/.github/workflows/create-draft-release.yaml
+++ b/.github/workflows/create-draft-release.yaml
@@ -1,0 +1,104 @@
+name: Create draft release
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+        description: 'The version of the plugin to release, e.g., 0.1.0'
+
+jobs:
+  create-draft-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+      - name: Setup Python 3.11.x
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Initialize Pants launcher
+        uses: pantsbuild/actions/init-pants@56efcdb79721bc7726edf542e324468033e4e21c
+        with:
+          # cache0 makes it easy to bust the cache if needed
+          gha-cache-key: cache0-py3.11
+          named-caches-hash: ${{ hashFiles('3rdparty/python/pants-2.29.lock') }}
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
+      - name: Run tests
+        run: "pants test ::"
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
+      - name: Package the plugin as a wheel
+        id: package
+        run: |
+          pants package src/python/shoalsoft/pants_mcp_plugin:wheel
+          wheel_file="dist/shoalsoft_pants_mcp_plugin-${{github.event.inputs.version}}-py3-none-any.whl"
+          if [ ! -r "$wheel_file" ]; then
+           ls dist/* || true
+            echo "ERROR: No wheel file found at $wheel_file." 1>&2
+            exit 1
+          fi
+          source_archive_file="dist/shoalsoft_pants_mcp_plugin-${{github.event.inputs.version}}.tar.gz"
+          if [ ! -r "$source_archive_file" ]; then
+           ls dist/* || true
+            echo "ERROR: No wheel file found at $wheel_file." 1>&2
+            exit 1
+          fi
+          echo "wheel-local-path=$wheel_file" >> $GITHUB_OUTPUT
+          echo "source-archive-file=$source_archive_file" >> $GITHUB_OUTPUT
+        env:
+          HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
+      - name: Attest provenance of the wheel and source archive.
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            ${{ steps.package.outputs.wheel-local-path }}
+            ${{ steps.package.outputs.source-archive-file }}
+      - name: Create the draft release.
+        uses: actions/github-script@v7
+        env:
+          PLUGIN_VERSION: ${{ github.event.inputs.version }}
+          REF: ${{ github.event.inputs.ref }}
+        with:
+          script: |
+            const pluginVersion = process.env.PLUGIN_VERSION;
+            const ref = process.env.REF;
+
+            const isPrerelease = pluginVersion.includes("dev") || pluginVersion.includes("rc");
+
+            const release = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: ref,
+              name: `v${pluginVersion}`,
+              body: `Release of version ${pluginVersion} of the Pants Model Context Protocol Plugin.`,
+              draft: true,
+              prerelease: isPrerelease,
+            });
+
+            return release.data;
+      - name: Upload the wheel and source archive to the draft release.
+        run: |
+          gh release upload ${{ github.event.inputs.ref }} ${{ steps.package.outputs.wheel-local-path }}
+          gh release upload ${{ github.event.inputs.ref }} ${{ steps.package.outputs.source-archive-file }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Upload pants.log
+        if: always()
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: pants-logs
+          overwrite: 'true'
+          path: .pants.d/workdir/*.log

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,88 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: true
+        type: string
+        description: 'The release to publish to PyPI'
+      publish_scope:
+        required: true
+        default: 'test-only'
+        type: choice
+        description: 'Publishing scope'
+        options:
+          - 'test-only'
+          - 'full'
+
+jobs:
+  validate-release:
+    name: Validate the release before distribution.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate the release.
+        run: |
+          gh release view "$RELEASE_TAG" --json=assets,isDraft > release-info.json
+          if [ "$(jq .isDraft release-info.json)" != "false" ]; then
+            echo "ERROR: Release $RELEASE_TAG is still in draft mode." 1>&2
+            exit 1
+          fi
+          if [ "$(jq '[.assets[] | select(.name | startswith("shoalsoft_"))] | length' release-info.json)" != "2" ]; then
+            echo "ERROR: Release $RELEASE_TAG does not have contain all of the expected assets." 1>&2
+            exit 1
+          fi
+          echo "SUCCESS: Release $RELEASE_TAG appears to be ready for distribution."
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+
+  testpypi-publish:
+    name: Upload release to TestPyPI
+    if: ${{ github.event.inputs.publish_scope == 'test-only' || github.event.inputs.publish_scope == 'full' }}
+    needs: validate-release
+    runs-on: ubuntu-24.04
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download the wheel and source archive from the draft release.
+        run: |
+          mkdir -p assets
+          gh release download --dir=assets --pattern='shoalsoft*' ${{ github.event.inputs.release_tag }}
+          ls -l assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+      - name: Publish package distributions to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: assets/
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+          print-hash: true
+
+  pypi-publish:
+    name: Upload release to PyPI
+    if: ${{ github.event.inputs.publish_scope == 'full' }}
+    needs: [validate-release, testpypi-publish]
+    runs-on: ubuntu-24.04
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download the wheel and source archive from the draft release.
+        run: |
+          mkdir -p assets
+          gh release download --dir=assets --pattern='shoalsoft*' ${{ github.event.inputs.release_tag }}
+          ls -l assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: assets/
+          verbose: true
+          print-hash: true

--- a/src/python/shoalsoft/pants_mcp_plugin/BUILD
+++ b/src/python/shoalsoft/pants_mcp_plugin/BUILD
@@ -11,7 +11,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-PLUGIN_VERSION = "0.1.0.dev0"
+PLUGIN_VERSION = "0.1.0.dev1"
 
 PANTS_MAJOR_MINOR_VERSIONS = ["2.29", "2.28", "2.27"]
 
@@ -90,3 +90,43 @@ def declare_pex_artifact(pants_major_minor_version):
 
 for pants_version in PANTS_MAJOR_MINOR_VERSIONS:
     declare_pex_artifact(pants_version)
+
+
+# This is a partial copy of the README.md geared more for the PyPI UX.
+LONG_DESCRIPTION = """\
+# Pantsbuild Model Context Protocol Plugin
+
+## Installation
+
+From PyPI:
+
+1. In the relevant Pants project, edit `pants.toml` to set the `[GLOBAL].plugins` option to include `shoalsoft-pants-mcp-plugin==VERSION` (replacing `VERSION` with the applicable version) and the `[GLOBAL].backend_packages` option to include `shoalsoft.pants_mcp_plugin`.
+
+2. Confogure your LLM coding agent to invoke `pants shoalsoft-mcp --run-stdio-server` in the repository as follows:
+
+  - [Claude Code setup](https://docs.claude.com/en/docs/claude-code/mcp#option-1%3A-add-a-local-stdio-server)
+  - [ChatGPT Codex setup](https://github.com/openai/codex/blob/main/docs/advanced.md#model-context-protocol-mcp)
+"""
+
+# Add a single wheel which is not specific to any particular Pants version.
+python_distribution(
+    name=f"wheel",
+    interpreter_constraints=[f"==3.11.*"],
+    provides=setup_py(
+        name="shoalsoft-pants-mcp-plugin",
+        description=f"Pantsbuild Model Context Protocol Plugin from Shoal Software LLC",
+        long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/markdown",
+        python_requires=f"==3.11.*",
+        version=PLUGIN_VERSION,
+        author="Tom Dyas",
+        author_email="tom@shoalsoftware.com",
+        url="https://github.com/shoalsoft/shoalsoft-pants-mcp-plugin",
+    ),
+    dependencies=[
+        f"./register.py@parametrize=pants-2.29",
+        # Exclude Pants and its transitive dependencies since the Pants will supply those
+        # dependencies itself from its own venv.
+        f"!!3rdparty/python:pants-2.29#pantsbuild.pants",
+    ],
+)


### PR DESCRIPTION
Add a GitHub Actions release workflow based on the [release workflow](https://github.com/shoalsoft/shoalsoft-pants-opentelemetry-plugin/blob/74d528ba19ed0ea838bc9d2e36a67703a30e3fa7/.github/workflows/create-draft-release.yaml) used for the `shoalsoft-pants-opentelemetry-plugin`. 