### PR TITLE
add permission for personal, non-commercial use

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ If the MCP server is started correctly by your LLM coding agent, then the agent 
 
 - Run tests: `pants test ::`
 
-### Building
-
-TBD
-
 ## License
 
 This is currently commercial software and requires prior permission to use. See the [LICENSE](./LICENSE) file in this repository for specific details.
+
+Permission is granted for personal, non-commercial use and for commercial evaluation, but not regular commercial use (which includes using the project for software development workflows in a commercial setting) without explicit permission.

--- a/src/python/shoalsoft/pants_mcp_plugin/BUILD
+++ b/src/python/shoalsoft/pants_mcp_plugin/BUILD
@@ -106,6 +106,12 @@ From PyPI:
 
   - [Claude Code setup](https://docs.claude.com/en/docs/claude-code/mcp#option-1%3A-add-a-local-stdio-server)
   - [ChatGPT Codex setup](https://github.com/openai/codex/blob/main/docs/advanced.md#model-context-protocol-mcp)
+
+## Licensing
+
+This project is commercial software subject [to a license](https://github.com/shoalsoft/shoalsoft-pants-mcp-plugin/blob/main/LICENSE).
+
+Permission is granted for personal, non-commercial use and for commercial evaluation, but not regular commercial use (which includes using the project for software development workflows in a commercial setting) without explicit permission.
 """
 
 # Add a single wheel which is not specific to any particular Pants version.


### PR DESCRIPTION
Add specific permission to use this plugin for personal, non-commercial uses and for evaluating a commercial use.